### PR TITLE
Add insert mode keybinding for Vi mode "insert"

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,1 +1,5 @@
 bind \c] 'fzf_ghq'
+
+if bind -M insert >/dev/null 2>/dev/null
+    bind -M insert \cg 'fzf_ghq'
+end


### PR DESCRIPTION
Handle insert vi mode, see https://fishshell.com/docs/current/#command-line-editor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tsub/fish-fzf-ghq/1)
<!-- Reviewable:end -->
